### PR TITLE
add package.json resolution to use version 1.2.6 of minimist

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,9 @@
     "react-visibility-sensor": "^5.0.2",
     "three": "0.126.0"
   },
+  "resolutions": {
+    "minimist": "^1.2.6"
+  },
   "peerDependencies": {
     "react": "^16.6.3",
     "react-dom": "^16.6.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6220,10 +6220,10 @@ minimatch@^3.0.4, minimatch@~3.0.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 mississippi@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Yarn audit was flagging version 1.2.5 and earlier of the minimist package as being vulnerable to prototype pollution.  There are mixed reports of if 1.2.6 will still be flagged or fix the issue but let's attempt the upgrade to unblock yarn audit if possible.